### PR TITLE
update en_us for consistency

### DIFF
--- a/src/main/resources/assets/transite/lang/en_us.json
+++ b/src/main/resources/assets/transite/lang/en_us.json
@@ -1,5 +1,5 @@
 {
-    "block.transite.raw_transite_block": "Raw Transite Block",
+    "block.transite.raw_transite_block": "Block of Raw Transite",
     "block.transite.transite_ore": "Transite Ore",
     "block.transite.deepslate_transite_ore": "Deepslate Transite Ore",
     "block.transite.transite_block": "Transite Block",


### PR DESCRIPTION
This changes "Raw Transite Block" into "Block of Raw Transite" keeping it consistent with Vanilla's naming scheme (e.g. "Block of Raw Gold")